### PR TITLE
make api polymorphic over floats

### DIFF
--- a/src/geo.rs
+++ b/src/geo.rs
@@ -2,11 +2,13 @@ use nalgebra::{ArrayStorage, Vector, Vector2, Vector3, U2, U3};
 
 use crate::interface::Vectorizable;
 
+#[derive(Debug, Clone)]
 pub struct Point<T = f32> {
     pub x: T,
     pub y: T,
 }
 
+#[derive(Debug, Clone)]
 pub struct Line<T = f32> {
     pub a: T,
     pub b: T,

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -2,29 +2,29 @@ use nalgebra::{ArrayStorage, Vector, Vector2, Vector3, U2, U3};
 
 use crate::interface::Vectorizable;
 
-pub struct Point {
-    pub x: f32,
-    pub y: f32,
+pub struct Point<T = f32> {
+    pub x: T,
+    pub y: T,
 }
 
-pub struct Line {
-    pub a: f32,
-    pub b: f32,
-    pub c: f32,
+pub struct Line<T = f32> {
+    pub a: T,
+    pub b: T,
+    pub c: T,
 }
 
-impl Point {
-    pub fn new(x: f32, y: f32) -> Self {
+impl<T> Point<T> {
+    pub fn new(x: T, y: T) -> Self {
         Point { x, y }
     }
 }
 
-impl Line {
-    pub fn new(a: f32, b: f32, c: f32) -> Self {
+impl<T: num_traits::Float> Line<T> {
+    pub fn new(a: T, b: T, c: T) -> Self {
         Line { a, b, c }
     }
 
-    pub fn from_points(p1: &Point, p2: &Point) -> Line {
+    pub fn from_points(p1: &Point<T>, p2: &Point<T>) -> Line<T> {
         let a = p2.y - p1.y;
         let b = p1.x - p2.x;
         let c = -a * p1.x - b * p1.y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,16 @@ use crate::pairs::PointPair;
 
 /// Represents restrictions for a homography computation.
 /// The restrictions are represented as a vector of 2x9 matrices.
+
+#[derive(Debug, Clone)]
 pub struct HomographyRestrictions<T: Scalar> {
     restrictions: Vec<Matrix2x9<T>>,
 }
 
 /// Represents a homography computation, which involves finding a transformation matrix
 /// that maps points and lines from one coordinate system to another.
+
+#[derive(Debug, Clone)]
 pub struct HomographyComputation<T = f32> {
     point_correspondences: Vec<PointPair<T>>,
     line_correspondences: Vec<LinePair<T>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ use crate::geo::{Line, Point};
 use crate::interface::{Matrix2x9, WithRestriction};
 use crate::pairs::LinePair;
 use nalgebra::{DMatrix, RealField, Scalar};
+use num_traits::Float;
 
 use crate::pairs::PointPair;
 
@@ -71,13 +72,13 @@ pub struct HomographyRestrictions<T: Scalar> {
 
 /// Represents a homography computation, which involves finding a transformation matrix
 /// that maps points and lines from one coordinate system to another.
-pub struct HomographyComputation {
-    point_correspondences: Vec<PointPair>,
-    line_correspondences: Vec<LinePair>,
+pub struct HomographyComputation<T = f32> {
+    point_correspondences: Vec<PointPair<T>>,
+    line_correspondences: Vec<LinePair<T>>,
 }
 
 /// Implementation of HomographyComputation, which represents a computation of homography.
-impl HomographyComputation {
+impl<T: Float + Scalar> HomographyComputation<T> {
     /// Creates a new instance of HomographyComputation.
     ///
     /// # Returns
@@ -96,7 +97,7 @@ impl HomographyComputation {
     ///
     /// * `p1` - The first point in the correspondence.
     /// * `p2` - The second point in the correspondence.
-    pub fn add_point_correspondence(&mut self, p1: Point, p2: Point) {
+    pub fn add_point_correspondence(&mut self, p1: Point<T>, p2: Point<T>) {
         self.point_correspondences.push(PointPair { p1, p2 });
     }
 
@@ -106,7 +107,7 @@ impl HomographyComputation {
     ///
     /// * `l1` - The first line in the correspondence.
     /// * `l2` - The second line in the correspondence.
-    pub fn add_line_correspondence(&mut self, l1: Line, l2: Line) {
+    pub fn add_line_correspondence(&mut self, l1: Line<T>, l2: Line<T>) {
         self.line_correspondences.push(LinePair { l1, l2 });
     }
 
@@ -115,7 +116,7 @@ impl HomographyComputation {
     /// # Returns
     ///
     /// The restrictions for the homography computation.
-    pub fn get_restrictions(&self) -> HomographyRestrictions<f32> {
+    pub fn get_restrictions(&self) -> HomographyRestrictions<T> {
         let mut restrictions = HomographyRestrictions {
             restrictions: Vec::new(),
         };
@@ -189,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_create_homography_computation() {
-        let hc = HomographyComputation::new();
+        let hc = HomographyComputation::<f32>::new();
         assert_eq!(hc.point_correspondences.len(), 0);
         assert_eq!(hc.line_correspondences.len(), 0);
     }

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -3,32 +3,33 @@ use crate::{
     interface::{Matrix2x9, WithRestriction},
 };
 
-use nalgebra::{ArrayStorage, Matrix, U1, U9};
+use nalgebra::{ArrayStorage, Matrix, Scalar, U1, U9};
+use num_traits::Float;
 
-pub struct PointPair {
-    pub p1: Point,
-    pub p2: Point,
+pub struct PointPair<T = f32> {
+    pub p1: Point<T>,
+    pub p2: Point<T>,
 }
 
-pub struct LinePair {
-    pub l1: Line,
-    pub l2: Line,
+pub struct LinePair<T = f32> {
+    pub l1: Line<T>,
+    pub l2: Line<T>,
 }
 
 type RowVector9<T> = Matrix<T, U1, U9, ArrayStorage<T, 1, 9>>;
 
-impl WithRestriction<f32> for PointPair {
-    fn generate_restriction(&self) -> Matrix2x9<f32> {
+impl<T: Float + Scalar> WithRestriction<T> for PointPair<T> {
+    fn generate_restriction(&self) -> Matrix2x9<T> {
         let p1 = &self.p1;
         let p2 = &self.p2;
 
         let first_row = RowVector9::from_vec(vec![
-            0.,
-            0.,
-            0.,
+            T::zero(),
+            T::zero(),
+            T::zero(),
             -p1.x,
             -p1.y,
-            -1.,
+            -T::one(),
             p1.x * p2.y,
             p1.y * p2.y,
             p2.y,
@@ -37,45 +38,45 @@ impl WithRestriction<f32> for PointPair {
         let second_row = RowVector9::from_vec(vec![
             p1.x,
             p1.y,
-            1.,
-            0.,
-            0.,
-            0.,
+            T::one(),
+            T::zero(),
+            T::zero(),
+            T::zero(),
             -p1.x * p2.x,
             -p1.y * p2.x,
             -p2.x,
         ]);
 
-        return Matrix2x9::from_rows(&vec![first_row, second_row]);
+        Matrix2x9::from_rows(&vec![first_row, second_row])
     }
 }
 
-impl WithRestriction<f32> for LinePair {
-    fn generate_restriction(&self) -> Matrix2x9<f32> {
+impl<T: Float + Scalar> WithRestriction<T> for LinePair<T> {
+    fn generate_restriction(&self) -> Matrix2x9<T> {
         let l1 = &self.l1;
         let l2 = &self.l2;
 
         let first_row = RowVector9::from_vec(vec![
-            0.,
+            T::zero(),
             -l1.c * l2.a,
             l1.b * l2.a,
-            0.,
+            T::zero(),
             -l1.c * l2.b,
             l1.b * l2.b,
-            0.,
+            T::zero(),
             -l1.c * l2.c,
             l1.b * l2.c,
         ]);
 
         let second_row = RowVector9::from_vec(vec![
             l1.c * l2.a,
-            0.,
+            T::zero(),
             -l1.a * l2.a,
             l1.c * l2.b,
-            0.,
+            T::zero(),
             -l1.a * l2.b,
             l1.c * l2.c,
-            0.,
+            T::zero(),
             -l1.a * l2.c,
         ]);
 

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -6,11 +6,13 @@ use crate::{
 use nalgebra::{ArrayStorage, Matrix, Scalar, U1, U9};
 use num_traits::Float;
 
+#[derive(Debug, Clone)]
 pub struct PointPair<T = f32> {
     pub p1: Point<T>,
     pub p2: Point<T>,
 }
 
+#[derive(Debug, Clone)]
 pub struct LinePair<T = f32> {
     pub l1: Line<T>,
     pub l2: Line<T>,


### PR DESCRIPTION
Adds polymorphism over types that implement `num_traits::Float`, mainly so that f64 can also be used
Also adds basic derives for public structs

Note: while I added the default type to all the structs that were non-polymorphic, it is still a breaking change, since the code won't compile on unconstrained initializations (as in `test_create_homography_computation`).
So maybe it is better to get rid of default types altogether